### PR TITLE
Réponses à tes remarques et plan d’action

### DIFF
--- a/automation_handler.py
+++ b/automation_handler.py
@@ -57,7 +57,6 @@ class AutomationHandler:
         a_min = c - temp_min
         a_max = temp_max - c
 
-        # Logs pour l'heure la plus chaude, la plage active et la température par défaut
         self.logger.info(f"Heure la plus chaude : {hottest_hour:.2f}h")
         self.logger.info(
             f"Plage active du chauffage : {start_hour:.2f}h - {end_hour:.2f}h"
@@ -115,22 +114,8 @@ class AutomationHandler:
                     preset["target_temperature_high"]
                 )
                 self.logger.info(
-                    f"Préréglage saisonnier mis à jour : {self.season_preset}, durée de variation : {self.heating_duration} heures"
+                    f"Action utilisateur : Préréglage saisonnier mis à jour : {self.season_preset}, durée de variation : {self.heating_duration} heures"
                 )
-                # Logs supplémentaires après changement de préréglage
-                hottest_hour = self.weather_client.get_hottest_hour()
-                start_hour = hottest_hour - (self.heating_duration / 2)
-                end_hour = hottest_hour + (self.heating_duration / 2)
-                if start_hour < 0:
-                    start_hour += 24
-                if end_hour >= 24:
-                    end_hour -= 24
-                self.logger.info(f"Heure la plus chaude : {hottest_hour:.2f}h")
-                self.logger.info(
-                    f"Plage active du chauffage : {start_hour:.2f}h - {end_hour:.2f}h"
-                )
-                self.logger.info(
-                    f"Température par défaut en dehors de la plage : {self.virtual_thermostat.target_temperature_low:.1f}°C"
-                )
+                # Les logs supplémentaires sont gérés par set_temperature/set_temperature_low/set_temperature_high
                 return
         self.logger.warning(f"Préréglage inconnu : {preset_name}")

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Yutampo2MQTT HA Addon"
-version: "2.0.2"
+version: "2.0.3"
 slug: "yutampo2mqtt"
 description: "Add-on pour intégrer le chauffe-eau Yutampo via CSNet avec automation interne"
 services:
@@ -17,7 +17,9 @@ options:
   username: "ton_username"
   password: "ton_password"
   scan_interval: 300
-  discovery_prefix: "homeassistant"  # Nouvelle option avec valeur par défaut
+  discovery_prefix: "homeassistant"
+  weather_entity: "weather.forecast_maison"  # Par défaut ton entité
+  log_level: "DEBUG"  # Par défaut DEBUG pour le développement
   presets:
     - name: "Hiver"
       target_temperature: 50
@@ -43,7 +45,9 @@ schema:
   username: str
   password: password
   scan_interval: int
-  discovery_prefix: str  # Ajout au schéma
+  discovery_prefix: str
+  weather_entity: str
+  log_level: list(DEBUG|INFO|WARNING|ERROR)  # Liste déroulante dans l’interface
   presets:
     - name: str
       target_temperature: float

--- a/virtual_thermostat.py
+++ b/virtual_thermostat.py
@@ -11,8 +11,8 @@ class VirtualThermostat:
         self.target_temperature_low = 41.0
         self.target_temperature_high = 49.0
         self.mode = "heat"
-        self.min_temp = 20  # Limite minimale globale
-        self.max_temp = 60  # Limite maximale globale
+        self.min_temp = 20
+        self.max_temp = 60
 
     def register(self):
         discovery_topic = (
@@ -81,12 +81,13 @@ class VirtualThermostat:
             )
             return
         self.target_temperature = temperature
-        self.logger.info(f"Consigne cible mise à jour : {self.target_temperature}°C")
-        # Recalculer les bornes en conservant l'amplitude existante si possible
         amplitude = (self.target_temperature_high - self.target_temperature_low) / 2
         self.target_temperature_low = max(self.min_temp, temperature - amplitude)
         self.target_temperature_high = min(self.max_temp, temperature + amplitude)
-        self.log_weather_info()
+        self.logger.info(
+            f"Action utilisateur : Consigne cible mise à jour à {self.target_temperature}°C"
+        )
+        self._log_weather_info()
         self.publish_state()
 
     def set_temperature_low(self, temperature_low):
@@ -97,9 +98,9 @@ class VirtualThermostat:
             return
         self.target_temperature_low = temperature_low
         self.logger.info(
-            f"Température basse mise à jour : {self.target_temperature_low}°C"
+            f"Action utilisateur : Température basse mise à jour à {self.target_temperature_low}°C"
         )
-        self.log_weather_info()
+        self._log_weather_info()
         self.publish_state()
 
     def set_temperature_high(self, temperature_high):
@@ -110,24 +111,20 @@ class VirtualThermostat:
             return
         self.target_temperature_high = temperature_high
         self.logger.info(
-            f"Température haute mise à jour : {self.target_temperature_high}°C"
+            f"Action utilisateur : Température haute mise à jour à {self.target_temperature_high}°C"
         )
-        self.log_weather_info()
+        self._log_weather_info()
         self.publish_state()
 
     def set_mode(self, mode):
         if mode in ["heat"]:
             self.mode = mode
+            self.logger.info(f"Action utilisateur : Mode mis à jour à {self.mode}")
             self.publish_state()
         else:
             self.logger.warning(f"Mode non supporté reçu : {mode}")
 
-    def log_weather_info(self):
-        """Ajoute des logs pour la météo et la plage active après un changement."""
-        from automation_handler import (
-            AutomationHandler,
-        )  # Import local pour éviter une dépendance circulaire
-
+    def _log_weather_info(self):
         if (
             hasattr(self.mqtt_handler, "automation_handler")
             and self.mqtt_handler.automation_handler


### PR DESCRIPTION
Entité météo weather.forecast_maison :

    Tu as raison de remettre en question l’approche via l’API Home Assistant (/core/api/states/weather.home). Bien que cela fonctionne dans un contexte où l’entité est bien définie, cela ajoute une dépendance inutile à l’API Supervisor et peut poser problème si l’entité n’est pas standard (weather.home dans ton cas n’existe pas, mais weather.forecast_maison oui).
    Solution proposée : Je vais modifier weather_client.py pour s’abonner directement au topic MQTT de l’état de l’entité météo spécifiée (weather.forecast_maison dans ton cas) via le broker MQTT. Cela utilise l’intégration MQTT native de Home Assistant, qui est plus robuste et évite les appels API. L’entité météo publiera ses prévisions dans un topic comme homeassistant/weather/forecast_maison/state, et nous pourrons les parser.

Vérification du token ha_token :

    Tu as raison, je vais ajouter un log pour confirmer que ha_token est bien récupéré dans yutampo_addon.py. Cependant, comme nous allons passer à une approche MQTT pour la météo, ce token ne sera plus nécessaire pour weather_client.py. Je garderai quand même le log pour d’autres usages futurs de l’API.

Niveau de logs configurable :

    Je vais ajouter une option log_level dans config.yaml et /data/options.json avec les valeurs possibles : DEBUG, INFO, WARNING, ERROR (par défaut INFO une fois le développement terminé, mais tu pourras laisser DEBUG pour l’instant).
    Le niveau sera appliqué globalement au logger dans yutampo_addon.py.

Logs des actions utilisateur en INFO :

    Toutes les actions utilisateur (changement de consigne via climate.yutampo_thermostat_virtual, changement de préréglage via input_select.yutampo_season_preset) seront loguées en INFO.
    Les informations importantes (plages actives, heure la plus chaude, température par défaut) seront également loguées en INFO lors de ces mises à jour.