### PR TITLE
Nouvelle méthode reset_forced_setpoint pour réinitialiser forced_setp…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Yutampo2MQTT HA Addon"
-version: "3.2.3"  
+version: "3.2.4"  
 slug: "yutampo2mqtt"
 description: "Add-on pour intégrer le chauffe-eau Yutampo via CSNet avec automation interne"
 services:
@@ -17,7 +17,7 @@ options:
   username: "ton_username"
   password: "ton_password"
   scan_interval: 300  
-  setpoint: 50.0  
+  setpoint: 50.0
   default_hottest_hour: 15.0
   log_level: "DEBUG"
   mqtt_host: "<auto_detect>"
@@ -29,9 +29,9 @@ schema:
   username: str
   password: password
   scan_interval: int
-  setpoint: float(30,60)  # Plage valide : 30°C à 60°C
-  discovery_prefix: str?  # Optionnel
-  weather_entity: str?  # Optionnel
+  setpoint: float(30,60)
+  discovery_prefix: str?
+  weather_entity: str?
   default_hottest_hour: float(0,23)
   log_level: list(VERBOSE|DEBUG|INFO|WARNING|ERROR)
   mqtt_host: str


### PR DESCRIPTION
Nouvelle méthode reset_forced_setpoint pour réinitialiser forced_setpoint et redémarrer l’automation.
Ajout de logs INFO :
Pour les commandes utilisateur (déjà dans mqtt_handler.py).
Pour les changements de consigne automatiques dans _run_automation (cas amplitude <= 0 et cas calculé).
Pour les transitions liées à forced_setpoint (atteinte ou non atteinte).
Clarification dans les logs : "consigne de référence" pour self.setpoint.