### PR TITLE
Gestion du mode via set_mode :

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: "Yutampo2MQTT HA Addon"
-version: "3.2.9"  
+version: "3.2.10"  
 slug: "yutampo2mqtt"
 description: "Add-on pour intégrer le chauffe-eau Yutampo via CSNet avec automation interne"
 services:


### PR DESCRIPTION
Gestion du mode via set_mode :
Dans la section if command == "mode" and topic_parts[-1] == "set", j’ai remplacé la logique manuelle (run_stop_dhw et reset_forced_setpoint) par un appel à self.automation_handler.set_mode(new_mode) si automation_handler existe.
Cela délègue la gestion du mode (y compris la réinitialisation de forced_setpoint et la reprise de la régulation) à AutomationHandler.set_mode, comme défini dans ma proposition précédente.
J’ai conservé une logique de fallback (sans set_mode) au cas où automation_handler ne serait pas défini, pour éviter de casser le code existant.
Suppression de reset_forced_setpoint manuel :
L’appel direct à self.automation_handler.reset_forced_setpoint() est supprimé, car set_mode gère cela automatiquement quand le mode passe à "heat". Cela évite les doublons et centralise la logique.
Conservation du reste :
Les autres parties (gestion de la consigne via set, input_number) restent inchangées, car elles fonctionnent bien et ne sont pas liées au problème de reprise de la régulation.
Explication
Quand tu passes de "off" à "heat" via HA ou CSNet Manager, le message arrive sur yutampo/climate/4103/mode/set. Avec cette modification, set_mode("heat") est appelé, ce qui :
Active le mode "heat" via set_heat_setting.
Réinitialise forced_setpoint à None.
Exécute immédiatement _run_automation pour appliquer la consigne calculée (46°C dans ton cas).