### PR TITLE
logs refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,17 @@ WORKDIR /app
 # Copie du code source
 COPY . /app
 
-RUN chmod +x /app/run.sh
+# Copie des fichiers de service s6-overlay
+COPY s6-services /etc/s6-overlay/s6-rc.d/
+
+
+# Rendre les scripts exécutables
+RUN chmod +x /app/run.sh && \
+    chmod +x /app/rc-init-wrapper.sh && \
+    chmod +x /etc/s6-overlay/s6-rc.d/yutampo-log/run
 
 # Exécution du script principal
+# CMD [ "/app/run.sh" ]
 
-CMD [ "/app/run.sh" ]
+# Exécution du script principal via le wrapper
+CMD [ "/app/rc-init-wrapper.sh" ]

--- a/ESP_OPTIONS/s6-services/type
+++ b/ESP_OPTIONS/s6-services/type
@@ -1,0 +1,1 @@
+longrun

--- a/ESP_OPTIONS/s6-services/user2/content.d/yutampo-log
+++ b/ESP_OPTIONS/s6-services/user2/content.d/yutampo-log
@@ -1,0 +1,1 @@
+yutampo-log

--- a/ESP_OPTIONS/s6-services/yutampo-log/consumer-for
+++ b/ESP_OPTIONS/s6-services/yutampo-log/consumer-for
@@ -1,0 +1,1 @@
+yutampo-log

--- a/ESP_OPTIONS/s6-services/yutampo-log/run
+++ b/ESP_OPTIONS/s6-services/yutampo-log/run
@@ -1,0 +1,2 @@
+#!/usr/bin/execlineb -P
+s6-log -b n10 s1000000 /var/log/yutampo

--- a/rc-init-wrapper.sh
+++ b/rc-init-wrapper.sh
@@ -1,0 +1,3 @@
+# rc-init-wrapper.sh
+#!/bin/sh -e
+exec /run/s6/basedir/scripts/rc.init top /app/run.sh 2>&1 | s6-fdholder-store /run/s6-rc/fdholder yutampo-log


### PR DESCRIPTION
remplace le mécanisme de log par défaut de s6-overlay (qui reformate les logs et filtre les codes ANSI) par un service s6-log qui capture les logs bruts dans /var/log/yutampo, préservant ainsi les codes ANSI. Cependant, cela peut affecter la manière dont Home Assistant affiche les logs, ce que nous ajusterons après le test.